### PR TITLE
Add recipe interactions feature to Umami demo

### DIFF
--- a/core/profiles/demo_umami/modules/umami_recipe_interactions/README.md
+++ b/core/profiles/demo_umami/modules/umami_recipe_interactions/README.md
@@ -1,0 +1,15 @@
+# Umami Recipe Interactions
+
+This module provides simple recipe rating and favorites functionality for the
+Umami demo profile. Authenticated users can rate each recipe from one to five
+stars and mark recipes as favorites. Average ratings are stored and updated per
+recipe while favorites are tracked per user.
+
+The module exposes two JSON endpoints used by the accompanying JavaScript
+library:
+
+- `/recipe/{node}/rate` – Accepts `POST` with a `rating` parameter.
+- `/recipe/{node}/favorite` – Toggles favorite status with a `POST` request.
+
+The JavaScript behavior is bundled with the Umami theme and automatically
+attached on recipe pages.

--- a/core/profiles/demo_umami/modules/umami_recipe_interactions/src/Controller/RecipeInteractionController.php
+++ b/core/profiles/demo_umami/modules/umami_recipe_interactions/src/Controller/RecipeInteractionController.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\umami_recipe_interactions\Controller;
+
+use Drupal\Core\Access\CsrfTokenGenerator;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Handles recipe rating and favorites.
+ */
+class RecipeInteractionController extends ControllerBase {
+
+  protected Connection $database;
+  protected AccountProxyInterface $currentUser;
+  protected CsrfTokenGenerator $csrfToken;
+
+  public function __construct(Connection $database, AccountProxyInterface $current_user, CsrfTokenGenerator $csrfToken) {
+    $this->database = $database;
+    $this->currentUser = $current_user;
+    $this->csrfToken = $csrfToken;
+  }
+
+  public static function create(ContainerInterface $container): self {
+    return new static(
+      $container->get('database'),
+      $container->get('current_user'),
+      $container->get('csrf_token')
+    );
+  }
+
+  /**
+   * Rate a recipe.
+   */
+  public function rate(NodeInterface $node, Request $request): JsonResponse {
+    $rating = (int) $request->request->get('rating');
+    if ($rating < 1 || $rating > 5) {
+      return new JsonResponse(['status' => 'error', 'message' => 'Invalid rating'], 400);
+    }
+    $uid = $this->currentUser->id();
+    $exists = $this->database->select('recipe_rating', 'r')
+      ->fields('r', ['rid'])
+      ->condition('nid', $node->id())
+      ->condition('uid', $uid)
+      ->execute()
+      ->fetchField();
+    if ($exists) {
+      $this->database->update('recipe_rating')
+        ->fields([
+          'rating' => $rating,
+          'timestamp' => time(),
+        ])
+        ->condition('rid', $exists)
+        ->execute();
+    }
+    else {
+      $this->database->insert('recipe_rating')
+        ->fields([
+          'nid' => $node->id(),
+          'uid' => $uid,
+          'rating' => $rating,
+          'timestamp' => time(),
+        ])
+        ->execute();
+    }
+    $average = $this->database->select('recipe_rating', 'r')
+      ->condition('nid', $node->id())
+      ->addExpression('AVG(rating)', 'avg')
+      ->execute()
+      ->fetchField();
+    return new JsonResponse(['status' => 'success', 'average' => round((float) $average, 2)]);
+  }
+
+  /**
+   * Toggle favorite status.
+   */
+  public function favorite(NodeInterface $node): JsonResponse {
+    $uid = $this->currentUser->id();
+    $exists = $this->database->select('recipe_favorite', 'f')
+      ->fields('f', ['fid'])
+      ->condition('nid', $node->id())
+      ->condition('uid', $uid)
+      ->execute()
+      ->fetchField();
+    if ($exists) {
+      $this->database->delete('recipe_favorite')
+        ->condition('fid', $exists)
+        ->execute();
+      $favorited = FALSE;
+    }
+    else {
+      $this->database->insert('recipe_favorite')
+        ->fields([
+          'nid' => $node->id(),
+          'uid' => $uid,
+          'timestamp' => time(),
+        ])
+        ->execute();
+      $favorited = TRUE;
+    }
+    return new JsonResponse(['status' => 'success', 'favorited' => $favorited]);
+  }
+
+}

--- a/core/profiles/demo_umami/modules/umami_recipe_interactions/umami_recipe_interactions.info.yml
+++ b/core/profiles/demo_umami/modules/umami_recipe_interactions/umami_recipe_interactions.info.yml
@@ -1,0 +1,5 @@
+name: 'Umami Recipe Interactions'
+type: module
+description: 'Adds recipe rating and favorites functionality.'
+package: 'Custom'
+core_version_requirement: ^10

--- a/core/profiles/demo_umami/modules/umami_recipe_interactions/umami_recipe_interactions.install
+++ b/core/profiles/demo_umami/modules/umami_recipe_interactions/umami_recipe_interactions.install
@@ -1,0 +1,106 @@
+<?php
+/**
+ * @file
+ * Install and uninstall hooks for Umami Recipe Interactions.
+ */
+
+use Drupal\Core\Database\SchemaObjectExistsException;
+
+/**
+ * Implements hook_install().
+ */
+function umami_recipe_interactions_install() {
+  $schema = _umami_recipe_interactions_schema();
+  foreach ($schema as $name => $table) {
+    try {
+      \Drupal::database()->schema()->createTable($name, $table);
+    }
+    catch (SchemaObjectExistsException $e) {
+      // Ignore if table already exists.
+    }
+  }
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function umami_recipe_interactions_uninstall() {
+  $schema = _umami_recipe_interactions_schema();
+  foreach (array_keys($schema) as $name) {
+    \Drupal::database()->schema()->dropTable($name);
+  }
+}
+
+/**
+ * Schema definition for recipe interactions tables.
+ */
+function _umami_recipe_interactions_schema() {
+  $schema = [];
+
+  $schema['recipe_rating'] = [
+    'fields' => [
+      'rid' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'nid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'uid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'rating' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'size' => 'tiny',
+      ],
+      'timestamp' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'Unix timestamp of rating creation.',
+      ],
+    ],
+    'primary key' => ['rid'],
+    'unique keys' => [
+      'user_recipe' => ['nid', 'uid'],
+    ],
+  ];
+
+  $schema['recipe_favorite'] = [
+    'fields' => [
+      'fid' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'nid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'uid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'timestamp' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => ['fid'],
+    'unique keys' => [
+      'user_recipe' => ['nid', 'uid'],
+    ],
+  ];
+
+  return $schema;
+}

--- a/core/profiles/demo_umami/modules/umami_recipe_interactions/umami_recipe_interactions.libraries.yml
+++ b/core/profiles/demo_umami/modules/umami_recipe_interactions/umami_recipe_interactions.libraries.yml
@@ -1,0 +1,8 @@
+interactions:
+  js:
+    ../../themes/umami/js/components/recipe-interactions/recipe-interactions.js: {}
+  dependencies:
+    - core/drupal
+    - core/jquery
+    - core/drupalSettings
+    - core/once

--- a/core/profiles/demo_umami/modules/umami_recipe_interactions/umami_recipe_interactions.module
+++ b/core/profiles/demo_umami/modules/umami_recipe_interactions/umami_recipe_interactions.module
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @file
+ * Module hooks for Umami Recipe Interactions.
+ */
+
+use Drupal\Core\Render\Markup;
+use Drupal\Core\Url;
+use Drupal\Core\Link;
+
+/**
+ * Implements hook_permission().
+ */
+function umami_recipe_interactions_permission() {
+  return [
+    'rate recipes' => [
+      'title' => t('Rate recipes'),
+      'description' => t('Allow users to rate recipes.'),
+    ],
+    'favorite recipes' => [
+      'title' => t('Favorite recipes'),
+      'description' => t('Allow users to mark recipes as favorites.'),
+    ],
+  ];
+}
+
+/**
+ * Implements hook_preprocess_node().
+ */
+function umami_recipe_interactions_preprocess_node(array &$variables) {
+  if ($variables['node']->bundle() === 'recipe') {
+    $variables['#attached']['library'][] = 'umami_recipe_interactions/interactions';
+  }
+}

--- a/core/profiles/demo_umami/modules/umami_recipe_interactions/umami_recipe_interactions.routing.yml
+++ b/core/profiles/demo_umami/modules/umami_recipe_interactions/umami_recipe_interactions.routing.yml
@@ -1,0 +1,25 @@
+umami_recipe_interactions.rate:
+  path: '/recipe/{node}/rate'
+  defaults:
+    _controller: '\Drupal\umami_recipe_interactions\Controller\RecipeInteractionController::rate'
+  requirements:
+    _permission: 'rate recipes'
+    node: '\d+'
+  options:
+    parameters:
+      node:
+        type: entity:node
+  methods: [POST]
+
+umami_recipe_interactions.favorite:
+  path: '/recipe/{node}/favorite'
+  defaults:
+    _controller: '\Drupal\umami_recipe_interactions\Controller\RecipeInteractionController::favorite'
+  requirements:
+    _permission: 'favorite recipes'
+    node: '\d+'
+  options:
+    parameters:
+      node:
+        type: entity:node
+  methods: [POST]

--- a/core/profiles/demo_umami/themes/umami/README.txt
+++ b/core/profiles/demo_umami/themes/umami/README.txt
@@ -3,6 +3,14 @@ ABOUT UMAMI
 
 Umami is the theme used for the "Umami food magazine" demonstration site.
 
+NEW FEATURES
+------------
+This profile now demonstrates recipe ratings and personal favorites.
+Authenticated users can rate each recipe from one to five stars and mark
+recipes they like as favorites. Ratings and favorites are handled by the
+`umami_recipe_interactions` module and displayed using a small JavaScript
+widget provided by the theme.
+
 ABOUT DRUPAL THEMING
 --------------------
 

--- a/core/profiles/demo_umami/themes/umami/js/components/recipe-interactions/recipe-interactions.js
+++ b/core/profiles/demo_umami/themes/umami/js/components/recipe-interactions/recipe-interactions.js
@@ -1,0 +1,37 @@
+((Drupal, once) => {
+  Drupal.behaviors.recipeInteractions = {
+    attach(context) {
+      once('recipe-interactions', '.recipe-rating', context).forEach((element) => {
+        element.querySelectorAll('input[type="radio"]').forEach((input) => {
+          input.addEventListener('change', (e) => {
+            const rating = e.target.value;
+            const url = e.target.dataset.url;
+            fetch(url, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+              },
+              body: 'rating=' + rating,
+            })
+              .then((res) => res.json())
+              .then((data) => {
+                if (data.average) {
+                  element.querySelector('.average-rating').textContent = data.average;
+                }
+              });
+          });
+        });
+      });
+      once('recipe-favorite', '.recipe-favorite', context).forEach((button) => {
+        button.addEventListener('click', (e) => {
+          e.preventDefault();
+          fetch(button.dataset.url, { method: 'POST' })
+            .then((res) => res.json())
+            .then((data) => {
+              button.classList.toggle('is-favorited', data.favorited);
+            });
+        });
+      });
+    },
+  };
+})(Drupal, once);

--- a/core/profiles/demo_umami/themes/umami/umami.libraries.yml
+++ b/core/profiles/demo_umami/themes/umami/umami.libraries.yml
@@ -171,3 +171,11 @@ drupal.node.preview:
   css:
     theme:
       css/components/content/node-preview.css: {}
+recipe-interactions:
+  js:
+    js/components/recipe-interactions/recipe-interactions.js: {}
+  dependencies:
+    - core/drupal
+    - core/jquery
+    - core/drupalSettings
+    - core/once


### PR DESCRIPTION
## Summary
- add new `umami_recipe_interactions` module
- implement DB schema, permissions and controller for rating/favorite endpoints
- load a JS behavior for rating & favorites
- document feature in theme README

## Testing
- `node --check core/profiles/demo_umami/themes/umami/js/components/recipe-interactions/recipe-interactions.js`
